### PR TITLE
NOISSUE: set actions/setup-python to v5 from v4

### DIFF
--- a/.github/workflows/ContinuousTesting.yml
+++ b/.github/workflows/ContinuousTesting.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           cache: 'pip'


### PR DESCRIPTION
- v5 setup-python action uses node.js 20 which github likes

![Screenshot 2024-02-02 162410](https://github.com/mahdiolfat/ssp/assets/1832251/fdf67dbc-98c1-4ffb-b5bf-b7874dfc83e2)